### PR TITLE
Add Cloudflare Turnstile to contact form

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ bun dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
+### Environment variables
+
+To enable the contact form protection you need to add the following variables to your `.env.local` file:
+
+```
+NEXT_PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY=<your site key>
+CLOUDFLARE_TURNSTILE_SECRET_KEY=<your secret key>
+```
+
+The site key is exposed to the browser for rendering the Turnstile widget, while the secret key is only used on the server to validate submitted tokens with Cloudflare.
+
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.

--- a/app/api/contact/route.tsx
+++ b/app/api/contact/route.tsx
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { telegramNotify } from "../../components/forms/telegram";
 import { validateCSRFToken } from "../../lib/csrf";
+import { verifyTurnstileToken } from "../../lib/turnstile";
 
 export async function POST(request: Request) {
   try {
@@ -20,6 +21,21 @@ export async function POST(request: Request) {
     const email = json.email;
     const phone = json.phone || "Not provided";
     const message = json.message;
+    const turnstileToken = json.turnstileToken;
+
+    if (!turnstileToken) {
+      return NextResponse.json({ result: false, error: 'Turnstile token missing' }, { status: 400 });
+    }
+
+    const ipAddress =
+      request.headers.get('CF-Connecting-IP') ||
+      request.headers.get('X-Real-IP') ||
+      request.headers.get('X-Forwarded-For')?.split(',')[0].trim();
+
+    const isHuman = await verifyTurnstileToken(turnstileToken, ipAddress ?? undefined);
+    if (!isHuman) {
+      return NextResponse.json({ result: false, error: 'Failed Cloudflare Turnstile verification' }, { status: 403 });
+    }
 
     // Format message for Telegram with HTML formatting
     const telegramMessage = `<b>New Contact Form Submission</b>\n\n<b>Name:</b> ${name}\n<b>Email:</b> ${email}\n<b>Phone:</b> ${phone}\n<b>Message:</b>\n${message}`;

--- a/app/components/forms/contact-form.tsx
+++ b/app/components/forms/contact-form.tsx
@@ -9,15 +9,19 @@ import {
   Input,
   Textarea,
 } from "@heroui/react";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { myProfile } from "../../config/site";
 import { AnimateIcon, EmailIcon, LocationIcon } from "../imgs/icons";
 import { sendGTMEvent } from "@next/third-parties/google";
+import { TurnstileWidget } from "./turnstile-widget";
 
 export function ContactForm() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [csrfToken, setCsrfToken] = useState<string>("");
+  const [captchaToken, setCaptchaToken] = useState<string>("");
+  const [captchaError, setCaptchaError] = useState<string>("");
+  const [captchaResetCounter, setCaptchaResetCounter] = useState(0);
 
   useEffect(() => {
     // Fetch CSRF token when component mounts
@@ -33,10 +37,22 @@ export function ContactForm() {
     fetchCSRFToken();
   }, []);
 
+  const resetCaptcha = useCallback(() => {
+    setCaptchaToken("");
+    setCaptchaError("");
+    setCaptchaResetCounter((prev) => prev + 1);
+  }, []);
+
   const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setIsSubmitting(true);
     sendGTMEvent({ event: "contactBtnClicked" });
+
+    if (!captchaToken) {
+      setCaptchaError("請完成 Cloudflare Turnstile 驗證");
+      setIsSubmitting(false);
+      return;
+    }
 
     try {
       const formData = new FormData(e.target as HTMLFormElement);
@@ -51,7 +67,7 @@ export function ContactForm() {
           "Content-Type": "application/json",
           "X-CSRF-Token": csrfToken,
         },
-        body: JSON.stringify({ name, email, phone, message }),
+        body: JSON.stringify({ name, email, phone, message, turnstileToken: captchaToken }),
       });
 
       if (response.ok) {
@@ -61,6 +77,7 @@ export function ContactForm() {
     } catch (error) {
       console.error("Error submitting form:", error);
     } finally {
+      resetCaptcha();
       setIsSubmitting(false);
     }
   };
@@ -232,6 +249,21 @@ export function ContactForm() {
                         }
                       }}
                     />
+                    <div className="space-y-2">
+                      <TurnstileWidget
+                        onVerify={(token) => {
+                          setCaptchaToken(token);
+                          setCaptchaError("");
+                        }}
+                        onExpire={() => {
+                          setCaptchaToken("");
+                        }}
+                        resetSignal={captchaResetCounter}
+                      />
+                      {captchaError && (
+                        <p className="text-danger text-sm">{captchaError}</p>
+                      )}
+                    </div>
                     <Button
                       type="submit"
                       color="primary"

--- a/app/components/forms/turnstile-widget.tsx
+++ b/app/components/forms/turnstile-widget.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import Script from "next/script";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+declare global {
+  interface Window {
+    turnstile?: {
+      render: (
+        element: HTMLElement,
+        options: {
+          sitekey: string;
+          callback: (token: string) => void;
+          "expired-callback"?: () => void;
+          "error-callback"?: () => void;
+          theme?: "light" | "dark" | "auto";
+        }
+      ) => string;
+      reset?: (widgetId?: string) => void;
+      remove?: (widgetId?: string) => void;
+    };
+  }
+}
+
+interface TurnstileWidgetProps {
+  onVerify: (token: string) => void;
+  onExpire: () => void;
+  resetSignal: number;
+}
+
+export function TurnstileWidget({ onVerify, onExpire, resetSignal }: TurnstileWidgetProps) {
+  const [scriptLoaded, setScriptLoaded] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const widgetIdRef = useRef<string | null>(null);
+  const siteKey = process.env.NEXT_PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY;
+
+  const renderWidget = useCallback(() => {
+    if (!scriptLoaded || !siteKey || !containerRef.current || widgetIdRef.current) {
+      return;
+    }
+
+    if (!window.turnstile) {
+      return;
+    }
+
+    widgetIdRef.current = window.turnstile.render(containerRef.current, {
+      sitekey: siteKey,
+      theme: "auto",
+      callback: (token: string) => {
+        onVerify(token);
+      },
+      "expired-callback": () => {
+        onExpire();
+      },
+      "error-callback": () => {
+        onExpire();
+      },
+    });
+  }, [scriptLoaded, siteKey, onVerify, onExpire]);
+
+  useEffect(() => {
+    renderWidget();
+  }, [renderWidget]);
+
+  useEffect(() => {
+    if (!widgetIdRef.current || !window.turnstile || typeof window.turnstile.reset !== "function") {
+      return;
+    }
+    window.turnstile.reset(widgetIdRef.current);
+  }, [resetSignal]);
+
+  useEffect(() => {
+    return () => {
+      if (widgetIdRef.current && window.turnstile && typeof window.turnstile.remove === "function") {
+        window.turnstile.remove(widgetIdRef.current);
+      }
+    };
+  }, []);
+
+  if (!siteKey) {
+    return (
+      <p className="text-danger text-sm">
+        尚未設定 Cloudflare Turnstile site key。
+      </p>
+    );
+  }
+
+  return (
+    <>
+      <Script
+        id="cloudflare-turnstile"
+        src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit"
+        strategy="afterInteractive"
+        onReady={() => setScriptLoaded(true)}
+      />
+      <div ref={containerRef} className="flex justify-center" />
+    </>
+  );
+}

--- a/app/lib/turnstile.ts
+++ b/app/lib/turnstile.ts
@@ -1,0 +1,45 @@
+interface TurnstileVerifyResponse {
+  success: boolean;
+  hostname?: string;
+  "error-codes"?: string[];
+}
+
+export async function verifyTurnstileToken(token: string, ipAddress?: string) {
+  const secretKey = process.env.CLOUDFLARE_TURNSTILE_SECRET_KEY;
+
+  if (!secretKey) {
+    console.error("CLOUDFLARE_TURNSTILE_SECRET_KEY is not configured");
+    return false;
+  }
+
+  const formData = new URLSearchParams();
+  formData.append("secret", secretKey);
+  formData.append("response", token);
+
+  if (ipAddress) {
+    formData.append("remoteip", ipAddress);
+  }
+
+  try {
+    const response = await fetch("https://challenges.cloudflare.com/turnstile/v0/siteverify", {
+      method: "POST",
+      body: formData,
+    });
+
+    if (!response.ok) {
+      console.error("Failed to verify Turnstile token", response.statusText);
+      return false;
+    }
+
+    const data = (await response.json()) as TurnstileVerifyResponse;
+
+    if (!data.success) {
+      console.warn("Turnstile verification failed", data["error-codes"]);
+    }
+
+    return data.success;
+  } catch (error) {
+    console.error("Error verifying Turnstile token", error);
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable Cloudflare Turnstile widget to the contact form and post its token with every submission
- verify tokens server-side before sending Telegram notifications and document the required environment variables
- add a helper for talking to the Turnstile verify API

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919ef8a84d8832ab4c869a1e3c8b942)